### PR TITLE
Enable RBAC support (added the "username" option in constructor)

### DIFF
--- a/lib/Couchbase/Bucket.pm
+++ b/lib/Couchbase/Bucket.pm
@@ -234,7 +234,7 @@ __END__
 Couchbase::Bucket - Couchbase Cluster data access
 
 
-=head1 SYNOPSIS
+=head1 SYNOPSIS 
 
 
     # Imports
@@ -242,7 +242,7 @@ Couchbase::Bucket - Couchbase Cluster data access
     use Couchbase::Document;
 
     # Create a new connection
-    my $cb = Couchbase::Bucket->new("couchbases://anynode/bucket", { password => "secret" });
+    my $cb = Couchbase::Bucket->new("couchbases://anynode/bucket", { username => "user" , password => "secret" });
 
     # Create and store a document
     my $doc = Couchbase::Document->new("idstring", { json => ["encodable", "string"] });
@@ -372,8 +372,8 @@ Additionally, ensure that the C<certpath> option contains the correct path, for 
 
 =head3 Specifying Bucket Credentials
 
-Often, the bucket will be password protected. You can specify the password using the
-C<password> option in the C<$options> hashref in the constructor.
+Often, the bucket will be password protected. You can specify the user credentials using the
+C<username> and C<password> options in the C<$options> hashref in the constructor.
 
 
 =head3 new($connstr, $options)

--- a/lib/Couchbase/N1QL/Handle.pm
+++ b/lib/Couchbase/N1QL/Handle.pm
@@ -71,8 +71,7 @@ sub row_callback {
             printf("$@: %s\n", $row);
         }
         # -- Fix for allowing list-type resultsets (eg using RAW in N1QL query ) --
-	    bless( ref $row ? $row : [ $row ] , 'Couchbase::N1QL::Row')  ;
-        #bless $row, 'Couchbase::N1QL::Row';
+	bless( ref $row ? $row : [ $row ] , 'Couchbase::N1QL::Row')  ;
         push @{$self->rows}, $row;
     }
 }

--- a/lib/Couchbase/N1QL/Handle.pm
+++ b/lib/Couchbase/N1QL/Handle.pm
@@ -70,7 +70,9 @@ sub row_callback {
             printf("Decoding error!\n");
             printf("$@: %s\n", $row);
         }
-        bless $row, 'Couchbase::N1QL::Row';
+        # -- Fix for allowing list-type resultsets (eg using RAW in N1QL query ) --
+	    bless( ref $row ? $row : [ $row ] , 'Couchbase::N1QL::Row')  ;
+        #bless $row, 'Couchbase::N1QL::Row';
         push @{$self->rows}, $row;
     }
 }

--- a/lib/Couchbase/N1QL/Handle.pm
+++ b/lib/Couchbase/N1QL/Handle.pm
@@ -60,7 +60,7 @@ sub process_meta {
 
     $self->_priv->{errinfo} = $self->meta->{errors};
 }
-use Robot::Logger ;
+
 sub row_callback {
     my ($self,$rows) = @_;
     if (!$rows) {

--- a/xs/Couchbase.xs
+++ b/xs/Couchbase.xs
@@ -36,6 +36,7 @@ PLCB_construct(const char *pkg, HV *hvopts)
     PLCB_t *object;
     plcb_OPTION options[] = {
         PLCB_KWARG("connstr", CSTRING, &cr_opts.v.v3.connstr),
+        PLCB_KWARG("username", CSTRING, &cr_opts.v.v3.username),
         PLCB_KWARG("password", CSTRING, &cr_opts.v.v3.passwd),
         PLCB_KWARG("io", SV, &iops_impl),
         PLCB_KWARG("on_connect", CV, &conncb),


### PR DESCRIPTION
**ADDED THE SUPPORT FOR RBAC.**

The Perl and the XS constructors allow the `username` in addition of the `password` option, enabling the *Role Based Access Control* introduced from Couchbase Server version 4.5.

Perl constructor usage:

```
use Couchbase::Bucket ;
my $bucket = Couchbase::Bucket->new(   
	"couchbase://127.0.0.1/bucket-name", 
	{ 
		username =>  "myUserName" ,  # <== new option 
		password => 'myPassword'
	}
) ;
```

**APPLIED PATCH**

```
--- xs/Couchbase.xs.orig	Mon Jul 23 23:41:36 2018
+++ xs/Couchbase.xs	Mon Jul 23 23:42:10 2018
@@ -36,6 +36,7 @@ PLCB_construct(const char *pkg, HV *hvopts)
     PLCB_t *object;
     plcb_OPTION options[] = {
         PLCB_KWARG("connstr", CSTRING, &cr_opts.v.v3.connstr),
+        PLCB_KWARG("username", CSTRING, &cr_opts.v.v3.username),
         PLCB_KWARG("password", CSTRING, &cr_opts.v.v3.passwd),
         PLCB_KWARG("io", SV, &iops_impl),
         PLCB_KWARG("on_connect", CV, &conncb),
```

**INSTALLATION**

The `xs/Couchbase.xs` was already patched with this commit.
Just compile and install the `Couchbase` Perl module as usual:
```
 perl Makerfile.PL
 make
 make install
```
**POD**

Only the POD of `Couchbase/Bucket.pm` was updated.

**TESTS**

Tests were not updated and the module was not well tested. Just only the connection and the RBAC compliance have been tested.