### PR TITLE
Enable RBAC support + sorted hashes

### DIFF
--- a/lib/Couchbase/Bucket.pm
+++ b/lib/Couchbase/Bucket.pm
@@ -234,7 +234,7 @@ __END__
 Couchbase::Bucket - Couchbase Cluster data access
 
 
-=head1 SYNOPSIS
+=head1 SYNOPSIS 
 
 
     # Imports
@@ -242,7 +242,7 @@ Couchbase::Bucket - Couchbase Cluster data access
     use Couchbase::Document;
 
     # Create a new connection
-    my $cb = Couchbase::Bucket->new("couchbases://anynode/bucket", { password => "secret" });
+    my $cb = Couchbase::Bucket->new("couchbases://anynode/bucket", { username => "user" , password => "secret" });
 
     # Create and store a document
     my $doc = Couchbase::Document->new("idstring", { json => ["encodable", "string"] });
@@ -372,8 +372,8 @@ Additionally, ensure that the C<certpath> option contains the correct path, for 
 
 =head3 Specifying Bucket Credentials
 
-Often, the bucket will be password protected. You can specify the password using the
-C<password> option in the C<$options> hashref in the constructor.
+Often, the bucket will be password protected. You can specify the user credentials using the
+C<username> and C<password> options in the C<$options> hashref in the constructor.
 
 
 =head3 new($connstr, $options)

--- a/lib/Couchbase/Bucket.pm
+++ b/lib/Couchbase/Bucket.pm
@@ -16,7 +16,7 @@ use Couchbase::View::Handle;
 use Couchbase::HTTPDocument;
 use Couchbase::N1QL::Handle;
 
-my $_JSON = Couchbase::JSON->new()->allow_nonref;
+my $_JSON = Couchbase::JSON->new()->allow_nonref->canonical;
 sub _js_encode { $_JSON->encode($_[0]) }
 sub _js_decode { $_JSON->decode($_[0]) }
 

--- a/lib/Couchbase/N1QL/Handle.pm
+++ b/lib/Couchbase/N1QL/Handle.pm
@@ -71,8 +71,7 @@ sub row_callback {
             printf("$@: %s\n", $row);
         }
         # -- Fix for allowing list-type resultsets (eg using RAW in N1QL query ) --
-	    bless( ref $row ? $row : [ $row ] , 'Couchbase::N1QL::Row')  ;
-        #bless $row, 'Couchbase::N1QL::Row';
+	bless( ref $row ? $row : [ $row ] , 'Couchbase::N1QL::Row')  ;
         push @{$self->rows}, $row;
     }
 }

--- a/lib/Couchbase/N1QL/Handle.pm
+++ b/lib/Couchbase/N1QL/Handle.pm
@@ -70,7 +70,9 @@ sub row_callback {
             printf("Decoding error!\n");
             printf("$@: %s\n", $row);
         }
-        bless $row, 'Couchbase::N1QL::Row';
+        # -- Fix for allowing list-type resultsets (eg using RAW in N1QL query ) --
+	    bless( ref $row ? $row : [ $row ] , 'Couchbase::N1QL::Row')  ;
+        #bless $row, 'Couchbase::N1QL::Row';
         push @{$self->rows}, $row;
     }
 }

--- a/lib/Couchbase/N1QL/Handle.pm
+++ b/lib/Couchbase/N1QL/Handle.pm
@@ -60,7 +60,7 @@ sub process_meta {
 
     $self->_priv->{errinfo} = $self->meta->{errors};
 }
-use Robot::Logger ;
+
 sub row_callback {
     my ($self,$rows) = @_;
     if (!$rows) {

--- a/xs/Couchbase.xs
+++ b/xs/Couchbase.xs
@@ -36,6 +36,7 @@ PLCB_construct(const char *pkg, HV *hvopts)
     PLCB_t *object;
     plcb_OPTION options[] = {
         PLCB_KWARG("connstr", CSTRING, &cr_opts.v.v3.connstr),
+        PLCB_KWARG("username", CSTRING, &cr_opts.v.v3.username),
         PLCB_KWARG("password", CSTRING, &cr_opts.v.v3.passwd),
         PLCB_KWARG("io", SV, &iops_impl),
         PLCB_KWARG("on_connect", CV, &conncb),


### PR DESCRIPTION
This PR sets "canonical" mode in JSON encoder, so that all documents are created with sorted hashes. Otherwise Perl randomizes them and they are difficult to analyze.

Also this PR embraces Annibale's RBAC support.